### PR TITLE
Updated UniDict.cfg

### DIFF
--- a/config/unidict/UniDict.cfg
+++ b/config/unidict/UniDict.cfg
@@ -39,7 +39,7 @@ general {
      >
 
     # keep only one entry per ore dict entry? [default: false]
-    B:keepOneEntry=true
+    B:keepOneEntry=false
 
     # mods listed here will be blacklisted in keepOneEntry.
     # must be the exact modID. [default: ]


### PR DESCRIPTION
This will essentially fix all current (and most likely future) bugs that may arise from UniDict's oreDict pruning interfering with things like loot tables and the like that we just have no control over. This will introduce one caveat; we'll have to deal with recipe cycling of ingots, nuggets, etc. when looking at recipes in JEI/NEI, as this will only hide the duplicate entries in JEI/NEI, but not physically remove their dictionary tags. There are probably better, more fine tuned ways to do this using these configs, but I'm simply sick of seeing problems arise like this. So, destroying a fly with a bazooka it is.