### PR TITLE
Added Configs for Villager Trade Tables

### DIFF
--- a/config/vtt.cfg
+++ b/config/vtt.cfg
@@ -1,0 +1,19 @@
+# Configuration file
+
+general {
+    #  [default: [minecraft:emerald]]
+    S:currencyItems <
+        minecraft:emerald
+     >
+
+    #  [default: true]
+    B:loadTradesFromJar=false
+
+    #  [default: true]
+    B:loadVillagersFromJar=false
+
+    #  [default: true]
+    B:sortTrades=true
+}
+
+

--- a/config/vtt/trade_tables/trackman.json
+++ b/config/vtt/trade_tables/trackman.json
@@ -1,0 +1,9 @@
+{ 
+	Profession: "railcraft:trackman", 
+	Career: "trackman",
+	Offers:{
+		Recipes:[
+			{action:"clear"}
+		]
+	}
+}


### PR DESCRIPTION
Currently Configured to Remove Trades from newly spawned Railcraft Trackman
Villagers.

Existing Trackman Villagers need to be put out of our misery