### PR TITLE
Additional CT Recipes

### DIFF
--- a/scripts/ForestryRecipes.zs
+++ b/scripts/ForestryRecipes.zs
@@ -1,3 +1,6 @@
+import minetweaker.item.IItemStack;
+import minetweaker.item.IIngredient;
+
 
 mods.forestry.Carpenter.addRecipe(<forestry:oakStick> * 2,
 	[[ <ore:logWood>],[<ore:logWood>]],20,<liquid:creosote> * 200);
@@ -42,3 +45,29 @@ mods.forestry.Carpenter.addRecipe(<immersiveengineering:treatedWood:0> * 8,
 	[[ <ore:plankWood>, <ore:plankWood>, <ore:plankWood>],
 	[<ore:plankWood>, null, <ore:plankWood>],
 	[<ore:plankWood>, <ore:plankWood>, <ore:plankWood>]], 20, <liquid:creosote> * 750);
+	
+var DYE_COLORS = [<ore:dyeWhite>,<ore:dyeOrange>,<ore:dyeMagenta>,<ore:dyeLightBlue>,<ore:dyeYellow>,<ore:dyeLime>,<ore:dyePink>,<ore:dyeGray>,<ore:dyeLightGray>,<ore:dyeCyan>,<ore:dyePurple>,<ore:dyeBlue>,<ore:dyeBrown>,<ore:dyeGreen>,<ore:dyeRed>,<ore:dyeBlack>] as IIngredient[];
+	
+for i, dye in DYE_COLORS {
+	
+	var powder = <chisel:concrete_powder>.definition.makeStack(i);
+	var block = <chisel:concrete>.definition.makeStack(i);
+
+mods.forestry.Carpenter.addRecipe(block * 8, 
+	[[ powder, powder, powder],
+	[powder, null, powder],
+	[powder, powder, powder]], 20, <liquid:water> * 100);	
+	
+mods.forestry.Carpenter.addRecipe(block * 8,
+	[[<ore:powderConcrete>,<ore:powderConcrete>,<ore:powderConcrete>],
+	[<ore:powderConcrete>, dye, <ore:powderConcrete>],
+	[<ore:powderConcrete>,<ore:powderConcrete>,<ore:powderConcrete>]], 20, <liquid:water> * 100);
+	
+mods.forestry.Carpenter.addRecipe(block * 8,
+	[[<ore:gravel>, <ore:sand>, <ore:gravel>],
+	[<ore:sand>, dye, <ore:sand>],
+	[<ore:gravel>, <ore:sand>, <ore:gravel>]], 20, <liquid:water> * 100);
+}
+	
+mods.forestry.Squeezer.addRecipe(<liquid:liquid_fertilizer> * 75, [<hatchery:chickenmanure>], 20);	
+mods.forestry.Squeezer.addRecipe(<liquid:liquid_fertilizer> * 750,[<hatchery:manure_block>], 20);

--- a/scripts/GeneralRecipes.zs
+++ b/scripts/GeneralRecipes.zs
@@ -1,3 +1,5 @@
+import minetweaker.item.IItemStack;
+
 //Recipe Removals
 recipes.remove(<extrautils2:itembuilderswand>);
 recipes.remove(<craftingtableiv:craftingtableiv>);
@@ -18,6 +20,9 @@ recipes.addShaped(<minecraft:blaze_rod>,
 //Convert Wheat into Seeds
 recipes.addShapeless(<minecraft:wheat_seeds>,[<minecraft:wheat>]);
 
+//Carrot to Carrot Seeds
+recipes.addShapeless(<agricraft:agri_seed>.withTag({agri_analyzed: 0 as byte, agri_strength: 1 as byte, agri_gain: 1 as byte, agri_seed: "carrot_plant", agri_growth: 1 as byte}),[<minecraft:carrot>]);
+
 //Name Tags
 recipes.addShaped(<minecraft:name_tag>, [[null, null, <ore:string>], [null, <thermalfoundation:material:832>, null], [<ore:paper>, null, null]]);
 
@@ -31,6 +36,7 @@ recipes.addShapeless(<actuallyadditions:itemMisc:5>,[<minecraft:quartz>,<minecra
 recipes.addShaped(<actuallyadditions:itemMisc:4>,
 	[[<minecraft:wheat>, <minecraft:wheat>],
 	[<minecraft:wheat>, null]]);
+
 //Spawner Shards
 recipes.addShaped(<actuallyadditions:itemMisc:20>,
 	[[<darkutils:material:0>,<minecraft:iron_bars>,<darkutils:material:0>],
@@ -50,6 +56,8 @@ recipes.addShaped(<forestry:fertilizerCompound> * 3,
 	[[<ore:manure>, <ore:manure>, <ore:manure>],
 	[<ore:dustWood>, <ore:dustWood>, <ore:dustWood>],
 	[<ore:manure>, <ore:manure>, <ore:manure>]]);
+	
+furnace.setFuel(<chickens:liquid_egg:1>,20000);
 	
 //Recipe for Log and Flint Chickens	
 recipes.addShapeless(<chickens:spawn_egg:108>, [<ore:listAllegg>, <ore:logWood>]);
@@ -115,3 +123,15 @@ recipes.remove(item);
 <ore:nuggetAluminum>.add(<agricraft:agri_nugget:8>);
 <ore:nuggetNickel>.add(<agricraft:agri_nugget:9>);
 <ore:nuggetPlatinum>.add(<agricraft:agri_nugget:10>);
+
+//Immersive Engineering
+//Wires for all the Shears
+var shears = [<botania:manasteelShears>,<botania:elementiumShears>,<railcraft:tool_shears_steel>,<thermalfoundation:tool.shears_wood>,<thermalfoundation:tool.shears_stone>,<thermalfoundation:tool.shears_diamond>,<thermalfoundation:tool.shears_gold>,<thermalfoundation:tool.shears_copper>,<thermalfoundation:tool.shears_tin>,<thermalfoundation:tool.shears_silver>,<thermalfoundation:tool.shears_lead>,<thermalfoundation:tool.shears_nickel>,<thermalfoundation:tool.shears_platinum>,<thermalfoundation:tool.shears_electrum>,<thermalfoundation:tool.shears_invar>,<thermalfoundation:tool.shears_bronze>] as IItemStack[];
+
+for shear in shears {
+	var tool = shear;	
+	recipes.addShapeless(<immersiveengineering:material:20>,[<ore:plateCopper>, tool.anyDamage().transformDamage()]);
+	recipes.addShapeless(<immersiveengineering:material:21>,[<ore:plateElectrum>, tool.anyDamage().transformDamage()]);
+	recipes.addShapeless(<immersiveengineering:material:22>,[<ore:plateAluminum>, tool.anyDamage().transformDamage()]);
+	recipes.addShapeless(<immersiveengineering:material:23>,[<ore:plateSteel>, tool.anyDamage().transformDamage()]);
+}

--- a/scripts/IERecipes.zs
+++ b/scripts/IERecipes.zs
@@ -1,8 +1,23 @@
+import minetweaker.item.IItemStack;
+import minetweaker.item.IIngredient;
 //mods.immersiveengineering.Mixer;
 
 //This is Waiting on IE version 58
-//Mixer.addRecipe(<liquid:crystaloil> * 1000, <liquid:oil> * 1000, [<actuallyadditions:itemMisc:23>], 2500);
-//Mixer.addRecipe(<liquid:empoweredoil> * 1000, <liquid:crystaloil> * 1000, [<actuallyadditions:itemMisc:24>], 2500);
-//Mixer.addRecipe(<liquid:liquid_fertilizer> * 1000, <liquid:water> * 1000, [<hatchery:manure_block>], 2500);
-//Mixer.addRecipe(<liquid:liquid_fertilizer> * 100, <liquid:water> * 100, [<hatchery:chickenmanure>], 2500);
+//mods.immersiveengineering.Mixer.addRecipe(<liquid:crystaloil> * 1000, <liquid:oil> * 1000, [<actuallyadditions:itemMisc:23>], 2500);
+//mods.immersiveengineering.Mixer.addRecipe(<liquid:empoweredoil> * 1000, <liquid:crystaloil> * 1000, [<actuallyadditions:itemMisc:24>], 2500);
+//mods.immersiveengineering.Mixer.addRecipe(<liquid:liquid_fertilizer> * 1000, <liquid:water> * 1000, [<hatchery:manure_block>], 2500);
+//mods.immersiveengineering.Mixer.addRecipe(<liquid:liquid_fertilizer> * 100, <liquid:water> * 100, [<hatchery:chickenmanure>], 2500);
 
+mods.immersiveengineering.Squeezer.addRecipe(null, <liquid:liquid_fertilizer> * 75, <hatchery:chickenmanure>,2500);
+mods.immersiveengineering.Squeezer.addRecipe(null, <liquid:liquid_fertilizer> * 750, <hatchery:manure_block>,2500);
+
+var DYE_COLORS = [<ore:dyeWhite>,<ore:dyeOrange>,<ore:dyeMagenta>,<ore:dyeLightBlue>,<ore:dyeYellow>,<ore:dyeLime>,<ore:dyePink>,<ore:dyeGray>,<ore:dyeLightGray>,<ore:dyeCyan>,<ore:dyePurple>,<ore:dyeBlue>,<ore:dyeBrown>,<ore:dyeGreen>,<ore:dyeRed>,<ore:dyeBlack>] as IIngredient[];
+	
+for i, dye in DYE_COLORS {
+	
+	var powder = <chisel:concrete_powder>.definition.makeStack(i);
+	var block = <chisel:concrete>.definition.makeStack(i);
+
+mods.immersiveengineering.BottlingMachine.addRecipe(block, powder, <liquid:water> * 10);
+
+}


### PR DESCRIPTION
Added new CraftTweaker Recipes for #20 :

Chisel Concrete can be Crafted in a Forestry Carpenter
- You can use any 8 Concrete Powder and 1 Dye to craft 8 Dye colored Concrete blocks
- You can use 4 Sand, 4 Gravel, and 1 Dye to craft 8 Dye colored Concrete blocks
- You can use 8 colored Concrete Powder to Craft 8 of the same colored Concrete blocks
  - https://puu.sh/vG7s6/ddc5fc8552.jpg

Added Forestry and Immersive Engineering Squeezer Recipe for Liquid Fertilizer
- 1 Chicken Manure yields 75mb Liquid Fertilizer
- 1 Manure Block yields 750mb Liquid Fertilizer

Added Immersive Engineering Bottling Machine Recipe for Chisel Concrete
- 1 Concrete Powder will yield 1 Concrete block of the appropriate color.
  - Not Practical, for show. Slow.
  - https://gfycat.com/WillingInsignificantAnchovy

Added Recipe to convert Carrot into Carrot Seeds
Added Lava Egg to Furnace fuel, cooks 100 items

Added Plate to Wire Recipes for Modded Shears including Botania, Railcraft, and Thermal Foundation
- Copper
- Electrum
- Aluminum
- Steel
